### PR TITLE
Add contributing guidelines

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: pnmadelaine

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and our
+community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project maintainers. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Typhon
+
+Welcome and thank you for your interest in contributing to Typhon! We appreciate
+your support.
+
+Participation in this community is governed by a [Code of
+Conduct](./CODE_OF_CONDUCT.md).
+
+Reading and following these guidelines will help us make the contribution
+process easy and effective for everyone involved.
+
+## Report a bug or a make a feature request
+
+1. Check on the issue tracker if it was already reported.
+
+2. If you were not able to find the bug or feature open a new issue.
+
+3. The more complete the information you provide, the more likely it can be
+   found by others and the more useful it is in the future. Make sure reported
+   bugs can be reproduced easily.
+
+## Making changes to Typhon
+
+1. Search for related issues that cover what you're going to work on. It could
+   help to mention there that you will work on the issue.
+
+   For far-reaching changes, please investigate possible blockers and design
+   implications, and coordinate with maintainers before investing too much time
+   in writing code that may not end up getting merged.
+
+   If there is no relevant issue yet and you're not sure whether your change is
+   likely to be accepted, open an issue yourself.
+
+2. Check for pull requests that might already cover the contribution you are
+   about to make.
+
+3. Check the [Typhon documentation](./doc/src/hacking.md) for information on
+   building Typhon and running it.
+
+4. Make your change!
+
+5. Create a pull request for your changes.
+
+   * Clearly explain the problem that you're solving. Link related issues to
+     inform interested parties and future contributors about your change. If
+     your pull request closes one or multiple issues, mention that in the
+     description using `Closes: #<number>`, as it will then happen automatically
+     when your change is merged.
+   * Make sure to have a clean history of commits on your branch to help with
+     the review process. Rebase when necessary but don't overuse force pushes
+     once the PR is opened as they mess up the discussion.
+   * Mark the pull request as draft if you're not done with the changes.
+
+## Getting help
+
+Whenever you're stuck or do not know how to proceed, you can always ask for
+help.


### PR DESCRIPTION
- add contributing guidelines inspired by the guidelines for Nix
- add the contributor covenant code of conduct v1.4
- add funding information