### PR TITLE
URL encoding of handles

### DIFF
--- a/nix/lib/github/mkGithubStatus.nix
+++ b/nix/lib/github/mkGithubStatus.nix
@@ -24,7 +24,9 @@ utils: lib: {
         token=$(echo "$input" | jq '.secrets.github_token' -r)
 
         rev=$(nix eval --json --expr "builtins.parseFlakeRef \"$url\"" | jq '.rev' -r)
-        target_url="${typhon_url}/evaluation/$evaluation/$system/$job"
+        system_encoded=$(echo -n "$system" | jq '@uri' -sRr)
+        job_encoded=$(echo -n "$job" | jq '@uri' -sRr)
+        target_url="${typhon_url}/evaluation/$evaluation/$system_encoded/$job_encoded"
         context="Typhon: $system / $job"
 
         case $status in

--- a/typhon-webapp/src/routes.rs
+++ b/typhon-webapp/src/routes.rs
@@ -281,21 +281,15 @@ impl TryFrom<Location> for Root {
 
 impl From<Root> for String {
     fn from(r: Root) -> Self {
-        fn path<T: Into<Vec<String>>>(handle: T) -> String {
-            let vec: Vec<String> = handle.into();
-            vec.iter()
-                .map(|s| urlencoding::encode(s).to_string())
-                .collect::<Vec<_>>()
-                .join("/")
-        }
+        use urlencoding::encode;
         match r {
             Root::Login => "/login".to_string(),
             Root::Dashboard { tab, page } => format!("/dashboard/{}?page={page}", tab),
             Root::Projects => "".to_string(),
-            Root::Project(handle) => format!("/project/{}", path(handle)),
+            Root::Project(handle) => format!("/project/{}", encode(&handle.name)),
             Root::Jobset { handle, page } => format!(
                 "/project/{}/jobset/{}?page={page}",
-                handle.project.name, handle.name
+                encode(&handle.project.name), encode(&handle.name)
             ),
             Root::Evaluation(e) => format!(
                 "/evaluation/{}/{}",
@@ -303,7 +297,7 @@ impl From<Root> for String {
                 match e.tab {
                     EvaluationTab::Job { handle, log_tab } => {
                         let log_tab: &str = log_tab.into();
-                        format!("{}/{}/{}", handle.system, handle.name, log_tab)
+                        format!("{}/{}/{}", encode(&handle.system), encode(&handle.name), log_tab)
                     }
                     EvaluationTab::Info => "".into(),
                 }

--- a/typhon-webapp/src/routes.rs
+++ b/typhon-webapp/src/routes.rs
@@ -289,7 +289,8 @@ impl From<Root> for String {
             Root::Project(handle) => format!("/project/{}", encode(&handle.name)),
             Root::Jobset { handle, page } => format!(
                 "/project/{}/jobset/{}?page={page}",
-                encode(&handle.project.name), encode(&handle.name)
+                encode(&handle.project.name),
+                encode(&handle.name),
             ),
             Root::Evaluation(e) => format!(
                 "/evaluation/{}/{}",
@@ -297,7 +298,12 @@ impl From<Root> for String {
                 match e.tab {
                     EvaluationTab::Job { handle, log_tab } => {
                         let log_tab: &str = log_tab.into();
-                        format!("{}/{}/{}", encode(&handle.system), encode(&handle.name), log_tab)
+                        format!(
+                            "{}/{}/{}",
+                            encode(&handle.system),
+                            encode(&handle.name),
+                            log_tab,
+                        )
                     }
                     EvaluationTab::Info => "".into(),
                 }


### PR DESCRIPTION
Handles contain arbitrary strings (project names, jobset names, job systems and job names), they need to be encoded inside URLs.

Closes: #9 