### PR TITLE
Fix ref parsing in `githubWebhook`

### DIFF
--- a/nix/lib/github/githubWebhook.nix
+++ b/nix/lib/github/githubWebhook.nix
@@ -22,7 +22,7 @@ utils: lib: {
 
       echo null | jq --argjson body "$body" '[]
         | if $body.created or $body.deleted then . + [{"command":"UpdateJobsets"}] else . end
-        | if $body.deleted | not then . + [{"command":"EvaluateJobset","name":$body.ref|split("/")|.[2]}] else . end
+        | if $body.deleted | not then . + [{"command":"EvaluateJobset","name":$body.ref|split("/")|.[2:]|join("/")}] else . end
         | .'
     '';
   };


### PR DESCRIPTION
Make `githubWebhook` parse refs properly when they contain more than two slashes.

Closes: #13 