### PR TITLE
Remove `set_private_key`

### DIFF
--- a/typhon-core/src/lib.rs
+++ b/typhon-core/src/lib.rs
@@ -151,7 +151,6 @@ pub fn handle_request_aux(
                 requests::Project::Info => return Ok(Response::ProjectInfo(project.info(conn)?)),
                 requests::Project::Refresh => project.refresh(conn)?,
                 requests::Project::SetDecl(decl) => project.set_decl(conn, decl)?,
-                requests::Project::SetPrivateKey(key) => project.set_private_key(conn, &key)?,
                 requests::Project::UpdateJobsets => project.update_jobsets(conn)?,
             };
             Response::Ok

--- a/typhon-core/src/projects.rs
+++ b/typhon-core/src/projects.rs
@@ -228,15 +228,6 @@ impl Project {
         Ok(())
     }
 
-    pub fn set_private_key(&self, conn: &mut Conn, key: &String) -> Result<(), Error> {
-        let _ = age::x25519::Identity::from_str(key).map_err(|_| Error::Todo)?;
-        diesel::update(&self.project)
-            .set(schema::projects::key.eq(key))
-            .execute(conn)?;
-        log_event(Event::ProjectUpdated(self.handle()));
-        Ok(())
-    }
-
     pub fn update_jobsets(&self, conn: &mut Conn) -> Result<(), Error> {
         // run action `jobsets`
         let action = self.new_action(

--- a/typhon-types/src/lib.rs
+++ b/typhon-types/src/lib.rs
@@ -315,7 +315,6 @@ pub mod requests {
         Info,
         Refresh,
         SetDecl(ProjectDecl),
-        SetPrivateKey(String),
         UpdateJobsets,
     }
 

--- a/typhon/src/api.rs
+++ b/typhon/src/api.rs
@@ -145,12 +145,6 @@ r!(
             Project::SetDecl(body.into_inner()),
         );
 
-    project_set_private_key(path: web::Path<String>, body: web::Json<String>) =>
-        Request::Project(
-            handles::project(path.into_inner()),
-            Project::SetPrivateKey(body.into_inner()),
-        );
-
     project_update_jobsets(path: web::Path<String>) =>
         Request::Project(
             handles::project(path.into_inner()),
@@ -353,7 +347,6 @@ pub fn config(cfg: &mut web::ServiceConfig) {
                     .route("/refresh", web::post().to(project_refresh))
                     .route("/update_jobsets", web::post().to(project_update_jobsets))
                     .route("/set_decl", web::post().to(project_set_decl))
-                    .route("/set_private_key", web::post().to(project_set_private_key))
                     .route("/webhook", web::post().to(webhook))
                     .service(
                         web::scope("/jobsets/{jobset}")


### PR DESCRIPTION
The `set_private_key` API endpoint was useful for debugging at some point, but there is no point in keeping it.