### PR TITLE
Get system from pkgs.stdenv.hostPlatform...

### DIFF
--- a/nix/nixos/typhon.nix
+++ b/nix/nixos/typhon.nix
@@ -23,7 +23,7 @@ in {
       description = "Which package to use for the Typhon instance";
       default = import ../packages/typhon.nix {
         inherit inputs;
-        inherit (config.nixpkgs) system;
+        inherit (pkgs.stdenv.hostPlatform) system;
       };
     };
     home = mkOption {


### PR DESCRIPTION
...instead of config.nixpkgs.

Without this, I encountered the following error while evaluating a host that includes typhons nixOS module.

```
error: Neither nixpkgs.system nor any other option in nixpkgs.* is meant to be read by modules and configurations.
Use pkgs.stdenv.hostPlatform instead.
```