### PR TITLE
New API for tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,7 +3972,6 @@ version = "0.0.1"
 dependencies = [
  "age",
  "argon2",
- "async-recursion",
  "async-stream",
  "async-trait",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ actix-session = { version = "0.9", features = ["cookie-session"] }
 actix-web = "4.4"
 age = { version = "0.9", features = ["armor"] }
 argon2 = "0.5"
-async-recursion = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
 clap = { version = "4.4", features = ["derive", "env"] }

--- a/typhon-core/Cargo.toml
+++ b/typhon-core/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 typhon-types.workspace = true
 age.workspace = true
 argon2.workspace = true
-async-recursion.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 diesel.workspace = true

--- a/typhon-core/src/error.rs
+++ b/typhon-core/src/error.rs
@@ -27,6 +27,7 @@ pub enum Error {
     LoginError,
     TaskError(task_manager::Error),
     BadWebhookOutput,
+    TokioError,
 }
 
 impl Error {
@@ -83,6 +84,7 @@ impl std::fmt::Display for Error {
             UnexpectedTimeError(e) => write!(f, "Time error: {}", e),
             TaskError(e) => write!(f, "Task error: {}", e),
             BadWebhookOutput => write!(f, "Bad webhook output"),
+            TokioError => write!(f, "Tokio error"),
         }
     }
 }
@@ -117,6 +119,12 @@ impl From<task_manager::Error> for Error {
     }
 }
 
+impl From<tokio::task::JoinError> for Error {
+    fn from(_: tokio::task::JoinError) -> Error {
+        Error::TokioError
+    }
+}
+
 impl Into<typhon_types::responses::ResponseError> for Error {
     fn into(self) -> typhon_types::responses::ResponseError {
         use {typhon_types::responses::ResponseError::*, Error::*};
@@ -125,6 +133,7 @@ impl Into<typhon_types::responses::ResponseError> for Error {
             | UnexpectedDatabaseError(_)
             | UnexpectedTimeError(_)
             | TaskError(_)
+            | TokioError
             | Todo => InternalError,
             EvaluationNotFound(_)
             | JobNotFound(_)

--- a/typhon-webapp/src/components/evaluations.rs
+++ b/typhon-webapp/src/components/evaluations.rs
@@ -95,7 +95,9 @@ impl EvalStatus {
             TaskStatusKind::Success => HybridStatusKind::EvalSucceeded {
                 build: self.jobs.unwrap_or_default().into(),
             },
-            TaskStatusKind::Failure | TaskStatusKind::Canceled => HybridStatusKind::EvalStopped,
+            TaskStatusKind::Failure | TaskStatusKind::Canceled | TaskStatusKind::Error => {
+                HybridStatusKind::EvalStopped
+            }
         }
     }
     pub fn summary(&self) -> TaskStatus {

--- a/typhon-webapp/src/components/status.rs
+++ b/typhon-webapp/src/components/status.rs
@@ -63,6 +63,7 @@ pub fn HybridStatus(#[prop(into)] status: Signal<HybridStatusKind>) -> impl Into
                                 TaskStatusKind::Pending => BiLoaderAltRegular,
                                 TaskStatusKind::Failure => BiXCircleSolid,
                                 TaskStatusKind::Canceled => BiStopCircleRegular,
+                                TaskStatusKind::Error => BiRadiationSolid,
                             }
                         }
                     };

--- a/typhon-webapp/src/pages/evaluation.rs
+++ b/typhon-webapp/src/pages/evaluation.rs
@@ -226,6 +226,7 @@ pub fn JobSubpage(
                             TaskStatus::Failure(..) => make("failed"),
                             TaskStatus::Canceled(Some(..)) => make("canceled"),
                             TaskStatus::Canceled(None) => view! { <>canceled</> },
+                            TaskStatus::Error(..) => view! { <>error</> },
                         }
                     }
 


### PR DESCRIPTION
- Define tasks imperatively, which should enable more complex processes (like runs) to be properly defined as tasks.
- Catch and log internal errors occuring in tasks.